### PR TITLE
fix build on Ubuntu Focal

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -8,6 +8,6 @@ links = "flux-core"
 [dependencies]
 
 [build-dependencies]
-bindgen = "0.49.0"
+bindgen = "^0.55.1"
 which = "2.0.1"
 

--- a/build.rs
+++ b/build.rs
@@ -3,7 +3,6 @@ extern crate bindgen;
 use std::env;
 use std::path::PathBuf;
 use std::process::Command;
-use std::string;
 use which::which;
 
 fn get_path_from_llvm(p: &str, s: &[&str]) -> PathBuf {

--- a/build.rs
+++ b/build.rs
@@ -24,7 +24,9 @@ fn main() {
     // shared library.
     println!("cargo:rustc-link-lib=flux-core");
 
-    if let Ok(llvm_config_path) = which("llvm-config") {
+    if let libclang_path = env::var("LIBCLANG_PATH") {
+        println!("LIBCLANG_PATH already set to {}, not overriding", libclang_path.unwrap());
+    } else if let Ok(llvm_config_path) = which("llvm-config") {
         let lc_str = llvm_config_path
             .to_str()
             .expect("llvm config path is not valid utf8");

--- a/build.rs
+++ b/build.rs
@@ -20,7 +20,7 @@ fn get_path_from_llvm(p: &str, s: &[&str]) -> PathBuf {
 }
 
 fn main() {
-    // Tell cargo to tell rustc to link the system bzip2
+    // Tell cargo to tell rustc to link the system flux-core
     // shared library.
     println!("cargo:rustc-link-lib=flux-core");
 


### PR DESCRIPTION
Problem: bindgen was struggling to find libclang on Ubuntu Focal (i.e.,
libclang-10.so.1) since it doesn't match any of its globs (i.e.,
'libclang.so', 'libclang-\*.so', 'libclang.so.\*').

Solution: bump the bindgen version to the 0.55.X series, which doesn't
seem to have this issue

Also includes a few other miscellaneous tweaks.