### PR TITLE
build: fix destructuring `if let`

### DIFF
--- a/build.rs
+++ b/build.rs
@@ -24,8 +24,11 @@ fn main() {
     // shared library.
     println!("cargo:rustc-link-lib=flux-core");
 
-    if let libclang_path = env::var("LIBCLANG_PATH") {
-        println!("LIBCLANG_PATH already set to {}, not overriding", libclang_path.unwrap());
+    if let Ok(libclang_path) = env::var("LIBCLANG_PATH") {
+        println!(
+            "LIBCLANG_PATH already set to {}, not overriding",
+            libclang_path
+        );
     } else if let Ok(llvm_config_path) = which("llvm-config") {
         let lc_str = llvm_config_path
             .to_str()

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -3,4 +3,3 @@
 #![allow(non_upper_case_globals)]
 
 include!(concat!(env!("OUT_DIR"), "/bindings.rs"));
-


### PR DESCRIPTION
Problem: the syntax used for the `if let` was incorrect, which I didn't catch until I tried to build `flux-rs` (probably wasn't the wisest to put all the CI in that repo)

Solution: fix the syntax to do the destructuring in the `if let` line